### PR TITLE
fix: added os type in package.json because in multi platform projects don't need to use the library in others sistems.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "install": "node-gyp rebuild",
     "test": "node index.js"
   },
-  "version": "1.0.3"
+  "version": "1.0.3",
+  "os": [
+    "darwin"
+  ]
 }


### PR DESCRIPTION
In multi plataforms projects when run a comand `npm install`, npm throw a error because is not possible to compile the library.